### PR TITLE
Added ability to target mouse position

### DIFF
--- a/Hush/Assets/Input/PlayerActions.inputactions
+++ b/Hush/Assets/Input/PlayerActions.inputactions
@@ -199,19 +199,8 @@
                 },
                 {
                     "name": "",
-                    "id": "c1f7a91b-d0fd-4a62-997e-7fb9b69bf235",
-                    "path": "<Gamepad>/rightStick",
-                    "interactions": "",
-                    "processors": "",
-                    "groups": ";Gamepad",
-                    "action": "Look",
-                    "isComposite": false,
-                    "isPartOfComposite": false
-                },
-                {
-                    "name": "",
                     "id": "8c8e490b-c610-4785-884f-f04217b23ca4",
-                    "path": "<Pointer>/delta",
+                    "path": "<Pointer>/position",
                     "interactions": "",
                     "processors": "",
                     "groups": ";Keyboard&Mouse",

--- a/Hush/Assets/Prefabs/Player/Player Base.prefab
+++ b/Hush/Assets/Prefabs/Player/Player Base.prefab
@@ -5405,6 +5405,7 @@ MonoBehaviour:
   speedChangeRate: 10
   animator: {fileID: 8205350870087033752}
   controller: {fileID: 2680335586944316230}
+  mainCamera: {fileID: 1005489440315475630}
 --- !u!114 &5076025907412216654
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Hush/Assets/Scenes/Dev Scene.unity
+++ b/Hush/Assets/Scenes/Dev Scene.unity
@@ -591,7 +591,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3946320261341067803, guid: 0a7eeb171ce643041827899f574c115a, type: 3}
       propertyPath: m_RootOrder
-      value: 12
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 3946320261341067803, guid: 0a7eeb171ce643041827899f574c115a, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1789,6 +1789,10 @@ PrefabInstance:
     - target: {fileID: 2694598201337503891, guid: 100992fbf20ff3b4caca1e6e2e308d2b, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4040321500388322195, guid: 100992fbf20ff3b4caca1e6e2e308d2b, type: 3}
+      propertyPath: attackPauseTime
+      value: 0.25
       objectReference: {fileID: 0}
     - target: {fileID: 5381592743170887637, guid: 100992fbf20ff3b4caca1e6e2e308d2b, type: 3}
       propertyPath: m_Name

--- a/Hush/Assets/Scripts/Game/InputManager.cs
+++ b/Hush/Assets/Scripts/Game/InputManager.cs
@@ -1,4 +1,5 @@
 using System;
+using UnityEditor;
 using UnityEngine;
 using UnityEngine.InputSystem;
 using static UnityEngine.InputSystem.InputAction;
@@ -32,17 +33,15 @@ namespace Player
 			DontDestroyOnLoad(Instance.gameObject);
 		}
 
-		private void Start()
-		{
-			// Lock the mouse cursor
-			Cursor.lockState = CursorLockMode.Locked;
-			Cursor.visible = false;
-		}
-
         private void OnDestroy()
         {
             if (Instance == this)
                 Instance = null;
+        }
+
+        private void Start()
+        {
+	        Cursor.lockState = CursorLockMode.Confined;
         }
 
         #region Public Event Handlers

--- a/Hush/Assets/Scripts/Player/Enums/PlayerAnimator.cs
+++ b/Hush/Assets/Scripts/Player/Enums/PlayerAnimator.cs
@@ -1,4 +1,4 @@
-﻿using UnityEngine;
+using UnityEngine;
 
 namespace Player.Enums
 {
@@ -10,11 +10,13 @@ namespace Player.Enums
         public static int SpellAttack => Animator.StringToHash("SpellAttack");
         public static int SpellSpecialAttack => Animator.StringToHash("SpellSpecialAttack");
         public static int Dead => Animator.StringToHash("Dead");
-        public static class Layer
+        
+        public enum Layer
         {
-            public static int Base => 0;
-            public static int UpperBody => 1;
+            Base = 0,
+            UpperBody = 1,
         }
+        
         public static class State
         {
             public static string LightAttack => "Light Attack";

--- a/Hush/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Hush/Assets/Scripts/Player/PlayerMovement.cs
@@ -111,7 +111,6 @@ namespace Player
             
             // Update the animator
             animator.SetFloat(PlayerAnimator.Speed, _playerSpeed);
-            Debug.Log(controller.velocity.magnitude);
         }
 
         private void RotatePlayer()

--- a/Hush/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Hush/Assets/Scripts/Player/PlayerMovement.cs
@@ -1,6 +1,9 @@
-﻿using Game;
+using System;
+using Common.Enums;
+using Game;
 using Player.Enums;
 using UnityEngine;
+using UnityEngine.InputSystem;
 
 namespace Player
 {
@@ -24,12 +27,17 @@ namespace Player
         [Header("Component References")] 
         [SerializeField] private Animator animator;
         [SerializeField] private CharacterController controller;
+        [SerializeField] private Camera mainCamera;
 
         #endregion
         
         private static InputManager Input => InputManager.Instance;
-
+        
+        private bool _isAttacking;
+        private float _attackDelta;
         private float _playerSpeed;
+
+        private float _attackPauseTime;
 
         private void Start()
         {
@@ -40,6 +48,15 @@ namespace Player
         {
             if (!GameManager.Instance.PlayerIsAlive)
                 return;
+
+            if (_attackDelta >= _attackPauseTime && _isAttacking)
+            {
+                _isAttacking = false;
+            }
+            else
+            {
+                _attackDelta += Time.fixedDeltaTime;
+            }
             
             MovePlayer();
             RotatePlayer();
@@ -56,15 +73,31 @@ namespace Player
             transform.position = GameManager.Instance.PlayerTransform.Position.Get();
             transform.rotation = GameManager.Instance.PlayerTransform.Rotation.Get();
             
-            _playerSpeed = 0f;
-            
             controller.enabled = true;
+        }
+
+        public void OnAttackPerformed(float delay)
+        {
+            _attackPauseTime = delay;
+            _attackDelta = 0f;
+
+            _isAttacking = true;
+            
+            // Set the target direction based on the input
+            var cameraRay = mainCamera.ScreenPointToRay(Input.look);
+            var groundPlane = new Plane(Vector3.up, transform.position);
+
+            if (!groundPlane.Raycast(cameraRay, out var rayLength)) 
+                return;
+            
+            var pointToLook = cameraRay.GetPoint(rayLength);
+            transform.LookAt(new Vector3(pointToLook.x, transform.position.y, pointToLook.z));
         }
 
         private void MovePlayer()
         {
             // Set target speed based on move speed, sprint speed and if sprint is pressed
-            float targetSpeed = Input.move.normalized.magnitude * (Input.walk ? walkSpeed : sprintSpeed);
+            float targetSpeed = Input.move.normalized.magnitude * GetDesiredSpeed();
             
             // Creates curved result rather than a linear one giving a more organic speed change
             _playerSpeed = Mathf.Lerp(_playerSpeed, targetSpeed, speedChangeRate * Time.deltaTime);
@@ -75,13 +108,17 @@ namespace Player
             
             // Move the player
             controller.Move(transform.TransformDirection(horizontalDisplacement + verticalDisplacement));
-
-            // Update animator
+            
+            // Update the animator
             animator.SetFloat(PlayerAnimator.Speed, _playerSpeed);
+            Debug.Log(controller.velocity.magnitude);
         }
 
         private void RotatePlayer()
         {
+            if (_isAttacking)
+                return;
+            
             // Set the target direction based on the input
             Vector3 targetDirection = new Vector3(Input.move.x, 0f, Input.move.y);
                 
@@ -91,6 +128,14 @@ namespace Player
             
             // Creates curved result rather than a linear one giving a more organic rotation change
             transform.rotation = Quaternion.Lerp(transform.rotation, Quaternion.LookRotation(targetDirection), rotationSpeed * Time.deltaTime);
+        }
+
+        private float GetDesiredSpeed()
+        {
+            if (_isAttacking)
+                return 0f;
+            
+            return Input.walk ? walkSpeed : sprintSpeed;
         }
     }
 }

--- a/Hush/Assets/Scripts/UI/PauseMenuUI.cs
+++ b/Hush/Assets/Scripts/UI/PauseMenuUI.cs
@@ -41,20 +41,12 @@ namespace UI
         {
             TimeManager.Instance.Pause();
             pauseMenuUI.SetActive(true);
-        
-            // Unlock the cursor
-            Cursor.lockState = CursorLockMode.None;
-            Cursor.visible = true;
         }
     
         private void Resume()
         {
             TimeManager.Instance.Resume();
             pauseMenuUI.SetActive(false);
-        
-            // Lock the cursor
-            Cursor.lockState = CursorLockMode.Locked;
-            Cursor.visible = false;
         }
     }
 }

--- a/Hush/Assets/Scripts/Weapon/PlayerSpell.cs
+++ b/Hush/Assets/Scripts/Weapon/PlayerSpell.cs
@@ -14,6 +14,9 @@ namespace Weapon
         [Header("Parameters")]
         [SerializeField] private float baseDamage = 5f;
         [SerializeField] private float heavyDamage = 15f;
+        [SerializeField] private float baseDuration = 0.25f;
+        [SerializeField] private float heavyDuration = 0.4f;
+        [SerializeField] private float castDelay = 0.1f;
     
         [Header("Spell References")]
         [SerializeField] private GameObject spellPrefab; 
@@ -21,14 +24,16 @@ namespace Weapon
     
         [Header("Other References")]
         [SerializeField] private Animator animator;
-    
+
         private static InputManager Input => InputManager.Instance;
 
         public WeaponType WeaponType => WeaponType.Spell;
 
         public float BaseDamage => baseDamage;
         public float HeavyDamage => heavyDamage;
-    
+
+        private PlayerMovement _player;
+
         private void OnEnable()
         {
             if (Input != null && Input.reference != null)
@@ -36,8 +41,13 @@ namespace Weapon
                 Input.reference.actions[Actions.LightSpell].performed += PerformAttack;
                 Input.reference.actions[Actions.HeavySpell].performed += PerformHeavyAttack;
             }
+
+            _player = FindObjectOfType<PlayerMovement>();
+
+            if (_player == null)
+                throw new MissingComponentException("Missing PlayerMovement Component in the Scene");
         }
-    
+
         private void OnDisable()
         {
             if (Input != null && Input.reference != null)
@@ -46,23 +56,23 @@ namespace Weapon
                 Input.reference.actions[Actions.HeavySpell].performed -= PerformHeavyAttack;
             }
         }
-    
+
         public void PerformAttack(InputAction.CallbackContext context)
         {
             if (!GameManager.Instance.PlayerIsAlive)
                 return;
-            
-            animator.SetTrigger(PlayerAnimator.SpellAttack);
-            CreateSpellAttack(AttemptCrit(BaseDamage));
+
+            _player.OnAttackPerformed(baseDuration);
+            Invoke(nameof(LightAttack), castDelay);
         }
 
         public void PerformHeavyAttack(InputAction.CallbackContext context)
         {
             if (!GameManager.Instance.PlayerIsAlive)
                 return;
-            
-            animator.SetTrigger(PlayerAnimator.SpellSpecialAttack);
-            CreateSpellAttack(AttemptCrit(HeavyDamage));
+
+            _player.OnAttackPerformed(heavyDuration);
+            Invoke(nameof(HeavyAttack), castDelay);
         }
 
         public float AttemptCrit(float damage)
@@ -70,12 +80,24 @@ namespace Weapon
             return damage;
         }
 
+        private void LightAttack()
+        {
+            animator.SetTrigger(PlayerAnimator.SpellAttack);
+            CreateSpellAttack(AttemptCrit(BaseDamage));
+        }
+
+        private void HeavyAttack()
+        {
+            animator.SetTrigger(PlayerAnimator.SpellSpecialAttack);
+            CreateSpellAttack(AttemptCrit(HeavyDamage));
+        }
+
         private void CreateSpellAttack(float damage)
         {
             var spellClone = Instantiate(spellPrefab);
             spellClone.transform.position = shootPosition.transform.position;
             spellClone.transform.rotation = shootPosition.transform.rotation;
-        
+
             spellClone.GetComponent<CustomFireProjectile>().ShootPosition = shootPosition.transform;
             spellClone.GetComponent<CustomFireProjectile>().Damage = (int)damage;
         }

--- a/Hush/Assets/Scripts/Weapon/PlayerSword.cs
+++ b/Hush/Assets/Scripts/Weapon/PlayerSword.cs
@@ -14,6 +14,11 @@ namespace Weapon
         [Header("Damage Parameters")]
         [SerializeField] private float baseDamage = 5;
         [SerializeField] private float heavyDamage = 15;
+        
+        [Header("Animation Parameters")]
+        [SerializeField] private float baseDuration = 0.3f;
+        [SerializeField] private float heavyDuration = 0.5f;
+        [SerializeField] private float castDelay = 0.15f;
     
         [Header("Crit Parameters")]
         [SerializeField] private float critChance = 0.10f;
@@ -30,6 +35,8 @@ namespace Weapon
         public float BaseDamage => baseDamage;
         public float HeavyDamage => heavyDamage;
 
+        private PlayerMovement _player;
+
         private void OnEnable()
         {
             if (Input != null && Input.reference != null)
@@ -37,6 +44,11 @@ namespace Weapon
                 Input.reference.actions[Actions.LightAttack].performed += PerformAttack;
                 Input.reference.actions[Actions.HeavyAttack].performed += PerformHeavyAttack;
             }
+
+            _player = FindObjectOfType<PlayerMovement>();
+
+            if (_player == null)
+                throw new MissingComponentException("Missing PlayerMovement Component in the Scene");
         }
 
         private void OnDisable()
@@ -58,7 +70,8 @@ namespace Weapon
             if (!GameManager.Instance.PlayerIsAlive)
                 return;
             
-            playerAnimator.SetTrigger(PlayerAnimator.LightAttack);
+            _player.OnAttackPerformed(baseDuration);
+            Invoke(nameof(LightAttack), castDelay);
         }
 
         public void PerformHeavyAttack(InputAction.CallbackContext context)
@@ -66,7 +79,8 @@ namespace Weapon
             if (!GameManager.Instance.PlayerIsAlive)
                 return;
             
-            playerAnimator.SetTrigger(PlayerAnimator.HeavyAttack);
+            _player.OnAttackPerformed(heavyDuration);
+            Invoke(nameof(HeavyAttack), castDelay);
         }
     
         public float AttemptCrit(float damage)
@@ -79,12 +93,22 @@ namespace Weapon
             return damage;
         }
 
+        private void LightAttack()
+        {
+            playerAnimator.SetTrigger(PlayerAnimator.LightAttack);
+        }
+
+        private void HeavyAttack()
+        {
+            playerAnimator.SetTrigger(PlayerAnimator.HeavyAttack);
+        }
+
         private void OnTriggerEnter(Collider col)
         {
             if (!col.CompareTag(Tags.Enemy) && !col.CompareTag(Tags.Dome)) 
                 return;
         
-            var stateInfo = playerAnimator.GetCurrentAnimatorStateInfo(PlayerAnimator.Layer.UpperBody);
+            var stateInfo = playerAnimator.GetCurrentAnimatorStateInfo((int)PlayerAnimator.Layer.UpperBody);
             var killable = col.GetComponent<IKillable>();
             if (stateInfo.IsName(PlayerAnimator.State.LightAttack))
             {


### PR DESCRIPTION
Should be similar to Hades controls

- Character points towards where they're going
- When you attack, attack in the direction the mouse points in
- Stop the player from moving for a brief moment
- Return to the default behaviour

When attacking, we need to add a tiny delay to let the player model rotate in the proper direction. The delay is currently 0.1 sec which makes it barely noticeable! Could be pushed even lower (down to 0.02s)